### PR TITLE
changed tmp dir to user-owned one to prevent race condition with multiple simulator sessions/users

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -101,7 +101,7 @@
 
 
 - (void)createStdioFIFO:(NSFileHandle **)fileHandle ofType:(NSString *)type atPath:(NSString **)path {
-  *path = [NSString stringWithFormat:@"/tmp/iphonesim-%@-pipe-%d", type, (int)time(NULL)];
+  *path = [NSString stringWithFormat:@"%@/iphonesim-%@-pipe-%d", NSTemporaryDirectory(), type, (int)time(NULL)];
   if (mkfifo([*path UTF8String], S_IRUSR | S_IWUSR) == -1) {
     nsprintf(@"Unable to create %@ named pipe `%@'", type, *path);
     exit(EXIT_FAILURE);


### PR DESCRIPTION
changed tmp dir to user-owned one to prevent race condition with multiple simulator sessions/users

when two users starts the simulator at the same time, the same pipe name was picked. i changed the code to chose the user owned temp dir.

it would be nice if you could merge my change...

thanks,

andreas
