### PR TITLE
Fix FIFO dumping to stdout/stderr.

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -97,6 +97,7 @@
   } else {
     nsprintf(str);
   }
+  [[notification object] readInBackgroundAndNotify];
 }
 
 


### PR DESCRIPTION
readInBackgroundAndNotify only registers a file handle for a single notification, so you have to call it again in the notification handler method to continue receiving notifications.
