### PR TITLE
ios-sim should exit immediately if app path doesn't exist

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -151,12 +151,15 @@
   DTiPhoneSimulatorSession *session;
   NSError *error;
 
+  NSFileManager *fileManager = [[[NSFileManager alloc] init] autorelease];
+  if (![fileManager fileExistsAtPath:path]) {
+    nsprintf(@"Application path %@ doesn't exist!", path);
+    exit(EXIT_FAILURE);
+  }
+
   /* Create the app specifier */
   appSpec = [DTiPhoneSimulatorApplicationSpecifier specifierWithApplicationPath:path];
-  if (appSpec == nil) {
-    nsprintf(@"Could not load application specification for %s", path);
-    return EXIT_FAILURE;
-  }
+
   if (verbose) {
     nsprintf(@"App Spec: %@", appSpec);
     nsprintf(@"SDK Root: %@", sdkRoot);


### PR DESCRIPTION
While setting up a continuous integration build for my iOS app, I noticed that ios-sim behaves unexpectedly when the app path doesn't exist: it launches the simulator with a blank screen, prints the following message:

[DEBUG] Session could not be started: Error Domain=DTiPhoneSimulatorErrorDomain Code=1 "Unknown error." UserInfo=0x10a81b5f0 {NSLocalizedDescription=Unknown error., DTiPhoneSimulatorUnderlyingErrorCodeKey=-1}

... and then continues running.

If the app path doesn't exist, ios-sim should print a useful error message and exit immediately without launching the simulator.  

Thanks!

--Dante
