### PR TITLE
Adds OCUnit parsing for more reliable exit codes

### DIFF
--- a/Source/iPhoneSimulator.h
+++ b/Source/iPhoneSimulator.h
@@ -11,9 +11,6 @@
 
 @interface iPhoneSimulator : NSObject <DTiPhoneSimulatorSessionDelegate> {
 @private
-    BOOL _parseTestOutput;
-    BOOL _testsFailed;
-    
   DTiPhoneSimulatorSystemRoot *sdkRoot;
   NSFileHandle *stdoutFileHandle;
   NSFileHandle *stderrFileHandle;
@@ -25,6 +22,8 @@
   BOOL alreadyPrintedData;
   BOOL retinaDevice;
   BOOL tallDevice;
+  BOOL parseTestOutput;
+  BOOL testsFailed;
 }
 
 - (void)runWithArgc:(int)argc argv:(char **)argv;

--- a/Source/iPhoneSimulator.h
+++ b/Source/iPhoneSimulator.h
@@ -11,6 +11,9 @@
 
 @interface iPhoneSimulator : NSObject <DTiPhoneSimulatorSessionDelegate> {
 @private
+    BOOL _parseTestOutput;
+    BOOL _testsFailed;
+    
   DTiPhoneSimulatorSystemRoot *sdkRoot;
   NSFileHandle *stdoutFileHandle;
   NSFileHandle *stderrFileHandle;

--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -19,18 +19,10 @@ NSString *deviceIphone = @"iPhone";
 NSString *deviceIpad = @"iPad";
 NSString *deviceIpadRetina = @"iPad (Retina)";
 
-@interface iPhoneSimulator ()
-@property (nonatomic) BOOL parseTestOutput;
-@property (nonatomic) BOOL testsFailed;
-@end
-
 /**
  * A simple iPhoneSimulatorRemoteClient framework.
  */
 @implementation iPhoneSimulator
-
-@synthesize parseTestOutput = _parseTestOutput;
-@synthesize testsFailed = _testsFailed;
 
 - (void) printUsage {
   fprintf(stderr, "Usage: ios-sim <command> <options> [--args ...]\n");
@@ -89,10 +81,10 @@ NSString *deviceIpadRetina = @"iPad (Retina)";
   }
 
   if (error != nil) {
-      if (self.parseTestOutput && [error.domain isEqualToString:@"DTiPhoneSimulatorErrorDomain"] && error.code == 1) {
+      if (parseTestOutput && [error.domain isEqualToString:@"DTiPhoneSimulatorErrorDomain"] && error.code == 1) {
           // This just means that the app exited. That's normal for testing. Base our return code
           // on whether the tests passed or failed.
-          if (self.testsFailed) {
+          if (testsFailed) {
               exit(EXIT_FAILURE);
           } else {
               exit(EXIT_SUCCESS);
@@ -149,7 +141,7 @@ NSString *deviceIpadRetina = @"iPad (Retina)";
     }
   }
 
-    if (self.parseTestOutput && !self.testsFailed) { // Don't need to check for failure if we've already failed
+    if (parseTestOutput && !testsFailed) { // Don't need to check for failure if we've already failed
         // Search for test failure information
         NSString *rpTestResultsLine = @"(^Executed .*)";
         NSString *rpNoFailures = @" 0 failures";
@@ -158,7 +150,7 @@ NSString *deviceIpadRetina = @"iPad (Retina)";
         NSRegularExpression *rxTestResultsLine = [NSRegularExpression regularExpressionWithPattern:rpTestResultsLine options:NSRegularExpressionAnchorsMatchLines error:&error];
         [rxTestResultsLine enumerateMatchesInString:str options:0 range:NSMakeRange(0, [str length]) usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
             if ([[str substringWithRange:[result range]] rangeOfString:rpNoFailures].location == NSNotFound) {
-                self.testsFailed = YES;
+                testsFailed = YES;
                 *stop = YES;
             }
         }];
@@ -379,7 +371,7 @@ NSString *deviceIpadRetina = @"iPad (Retina)";
       } else if (strcmp(argv[i], "--use-gdb") == 0) {
         useGDB = YES;
       } else if (strcmp(argv[i], "--unit-testing") == 0) {
-          self.parseTestOutput = YES;
+          parseTestOutput = YES;
       }
       else if (strcmp(argv[i], "--sdk") == 0) {
         i++;

--- a/Source/main.m
+++ b/Source/main.m
@@ -22,6 +22,7 @@ int main (int argc, char *argv[]) {
     /* Run the loop to handle added input sources, if any */
     [[NSRunLoop mainRunLoop] run];
 
+    [sim release];
     [pool release];
     return 0;
 }


### PR DESCRIPTION
We're trying to use ios-sim to run tests in the iOS simulator on our continuous integration server. We ran into a problem where ios-sim always returned a failing exit code because it wasn't expecting the simulated app to exit after the tests ran and treated that as an error. These changes add a new "--unit-testing" parameter that turns on parsing of the simulator's output looking for OCUnit's end of a test suite message to determine whether the tests passed or failed. If any tests failed, then we return an error code on exit. If all tests pass, we return 0 on exit.

Sending a pull request in case other users would find this functionality helpful. This is my first pull request, so please let me know if it's not appropriate for the project or if I should set it up differently.
