### PR TITLE
Update SimulateDevice value format

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -13,8 +13,8 @@
 
 NSString *simulatorPrefrencesName = @"com.apple.iphonesimulator";
 NSString *deviceProperty = @"SimulateDevice";
-NSString *deviceIphoneRetina3_5Inch = @"iPhone (Retina 3.5-inch)";
-NSString *deviceIphoneRetina4_0Inch = @"iPhone (Retina 4-inch)";
+NSString *deviceIphoneRetina3_5Inch = @"iPhone Retina (3.5-inch)";
+NSString *deviceIphoneRetina4_0Inch = @"iPhone Retina (4-inch)";
 NSString *deviceIphone = @"iPhone";
 NSString *deviceIpad = @"iPad";
 NSString *deviceIpadRetina = @"iPad (Retina)";


### PR DESCRIPTION
Format of com.apple.iphonesimulator SimulateDevice changed since some
xcode version

This fixes the --tall argument for recent simulator versions
