### PR TITLE
Xcode 6 support for specifying the os version of the simulator

### DIFF
--- a/Source/iPhoneSimulator.m
+++ b/Source/iPhoneSimulator.m
@@ -190,7 +190,7 @@ NSString* FindDeveloperDir() {
         SimDeviceSet* deviceSet = [simDeviceSet defaultSet];
         NSArray* devices = [deviceSet availableDevices];
         for (SimDevice* device in devices) {
-            nsfprintf(stderr, @"%@", device.deviceType.identifier);
+            nsfprintf(stderr, @"%@, %@", device.deviceType.identifier, device.runtime.versionString);
         }
     }
 
@@ -451,12 +451,25 @@ static void ChildSignal(int arg) {
 
     SimDeviceSet* deviceSet = [[self FindClassByName:@"SimDeviceSet"] defaultSet];
     NSArray* devices = [deviceSet availableDevices];
-    for (SimDevice* device in devices) {
-        SimDeviceType* type = device.deviceType;
-        if ([type.identifier isEqualToString:devTypeId]) {
-            return device;
-        }
-    }
+	NSArray* deviceTypeAndVersion = [devTypeId componentsSeparatedByString:@","];
+	if(deviceTypeAndVersion.count == 2) {
+		NSString* typeIdentifier = [deviceTypeAndVersion.firstObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+		NSString* versionString = [deviceTypeAndVersion.lastObject stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];;
+		for (SimDevice* device in devices) {
+			if ([device.deviceType.identifier isEqualToString:typeIdentifier] && [device.runtime.versionString isEqualToString:versionString]) {
+				return device;
+			}
+		}
+	}
+	//maintain old behavior (if the device identifier doesn't have a version as part of the identifier, loop through to find the first matching)
+	else
+	{
+		for (SimDevice* device in devices) {
+			if ([device.deviceType.identifier isEqualToString:devTypeId]) {
+				return device;
+			}
+		}
+	}
     // Default to whatever is the first device
     return [devices count] > 0 ? [devices objectAtIndex:0] : nil;
 }


### PR DESCRIPTION
When pull request 91 (Added initial Xcode6 beta (6A215l) support) was merged in, it did not allow you to choose between conflicting device identifiers.
For example you could have:
- com.apple.CoreSimulator.SimDeviceType.iPhone-4s
- A bunch of other identifiers
- com.apple.CoreSimulator.SimDeviceType.iPhone-4s

This will happen if you have your iOS 8 sdk, and any old iOS simulators (iOS 7.0.3 or 7.1) installed.

In order to differentiate between the simulators, it will print out
- com.apple.CoreSimulator.SimDeviceType.iPhone-4s, 7.0.3
- com.apple.CoreSimulator.SimDeviceType.iPhone-4s, 8.0

Then you use as you would before:

```
./ios-sim --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-4s, 8.0"
```

The old way which does not include the iOS version in the string will still work by looping through the devices and selecting the first one with a matching identifier.
