### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Make sure you enable Developer Mode on your machine:
 
 Make sure multiple instances of launchd_sim are not running:
     
-    $ killall launchd_sim
+    $ sudo ps -A | grep -e "launchd_sim" -e "simulator" -i | grep -v grep | awk '{print $1}' | xargs kill -9
     
 Development
 -----------


### PR DESCRIPTION
In the docs it mentions to use killall launchd_sim, but this only works if you closed the application prior to running the command and ocassionally i've seen the services not exit in certain conditions.

Suggest to replace it with

sudo ps -A | grep -e "launchd_sim" -e "simulator" -i | grep -v grep | awk '{print $1}' | xargs kill -9
