### PR TITLE
package.json use plist@3 & sort dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "author": "Shazron Abdullah",
   "license": "MIT",
   "dependencies": {
-    "plist": "^1.2.0",
-    "simctl": "^1.1.1",
+    "bplist-parser": "^0.0.6",
     "nopt": "1.0.9",
-    "bplist-parser": "^0.0.6"
+    "plist": "^3.0.1",
+    "simctl": "^1.1.1"
   },
   "devDependencies": {
     "jasmine": "~2.6.0",


### PR DESCRIPTION
resolves some of the ugly deprecation warnings, passes existing spec

wanted to resolve some of the ugly warnings in upstream cordova-ios project

minor version bump is recommended, small chance that a major version bump may be warranted