### PR TITLE
Migrate to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,16 @@
+root: true
+
+extends: semistandard
+
+rules:
+  indent:
+    - error
+    - 4
+
+  no-unused-vars:
+    - error
+    - args: after-used
+
+  # excpetions specified in:
+  # - src/.eslintrc.yml
+  # - spec/.eslintrc.yml

--- a/package.json
+++ b/package.json
@@ -30,16 +30,19 @@
     "simctl": "^1.1.1"
   },
   "devDependencies": {
-    "jasmine": "~2.6.0",
-    "jscs": "^2.11.0",
-    "jshint": "^2.9.1"
+    "eslint": "^4.19.1",
+    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
+    "jasmine": "~2.6.0"
   },
   "scripts": {
+    "eslint": "eslint *.js src spec",
     "test": "npm run jasmine",
-    "posttest": "npm run jshint",
-    "jshint": "jshint src ./ios-sim.js",
-    "postjshint": "npm run jscs",
-    "jscs": "jscs src ./ios-sim.js",
+    "posttest": "npm run eslint",
     "jasmine": "jasmine --config=spec/jasmine.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "author": "Shazron Abdullah",
   "license": "MIT",
   "dependencies": {
-    "plist": "^1.2.0",
-    "simctl": "^1.1.1",
+    "bplist-parser": "^0.0.6",
     "nopt": "1.0.9",
-    "bplist-parser": "^0.0.6"
+    "plist": "^3.0.1",
+    "simctl": "^1.1.1"
   },
   "devDependencies": {
     "jasmine": "~2.6.0",

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,0 +1,19 @@
+env:
+    jasmine: true
+
+rules:
+  # TBD easy fix:
+  padded-blocks: off
+  spaced-comment: off
+
+  # TODO resolve:
+  eol-last: off
+  semi: off
+
+  # TBD easy resolve:
+  key-spacing: off
+
+  # FUTURE TBD:
+  indent: off
+  quotes: off
+  space-before-function-paren: off

--- a/src/.eslintrc.yml
+++ b/src/.eslintrc.yml
@@ -1,0 +1,21 @@
+rules:
+  # common src exception:
+  camelcase: off
+
+  # TBD easy fix:
+  padded-blocks: off
+
+  # TODO resolve:
+  eqeqeq: off
+  no-unused-vars: off
+  node/no-deprecated-api: off
+
+  # TBD easy resolve:
+  comma-spacing: off
+  no-useless-escape: off
+
+  # FUTURE TBD:
+  no-multiple-empty-lines: off
+  one-var: off
+  spaced-comment: off
+  space-before-function-paren: off


### PR DESCRIPTION
.eslintrc files based on .eslintrc files in cordova-common

with some TBD/TODO items marked in `.eslintrc.yml` & `spec/.eslintrc.yml`

includes update to use plist@3 as proposed in #229 

The changes proposed here, including the changes proposed in #229, would resolve the ugly deprecation warnings generated by `npm install`. These changes are wanted to resolve some of the ugly warnings in the upstream cordova-ios package.