### PR TITLE
plist@2 patch

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,16 @@
+root: true
+
+extends: semistandard
+
+rules:
+  indent:
+    - error
+    - 4
+
+  no-unused-vars:
+    - error
+    - args: after-used
+
+  # excpetions specified in:
+  # - src/.eslintrc.yml
+  # - spec/.eslintrc.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
-language: node_js
+os: osx
+osx_image: xcode8.3
 sudo: false
+env:
+  matrix:
+  - TRAVIS_NODE_VERSION: '4'
+  - TRAVIS_NODE_VERSION: '6'
 git:
   depth: 10
-node_js:
-- '4'
-- '6'
+before_install:
+- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
+  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
+  install $TRAVIS_NODE_VERSION
+- node --version
+- npm --version
+- npm cache clean
+- npm install -g npm@3
 install:
 - npm install
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm cache clean
+  - npm install -g npm@3
   - npm install
 
 build: off

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim",
-  "version": "6.1.2",
+  "version": "6.1.3-dev",
   "preferGlobal": "true",
   "description": "launch iOS apps into the iOS Simulator from the command line (Xcode 8.0+)",
   "main": "ios-sim.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "ios-sim.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/phonegap/ios-sim"
+    "url": "https://github.com/ios-control/ios-sim"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -30,16 +30,19 @@
     "bplist-parser": "^0.0.6"
   },
   "devDependencies": {
-    "jasmine": "~2.6.0",
-    "jscs": "^2.11.0",
-    "jshint": "^2.9.1"
+    "eslint": "^4.19.1",
+    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
+    "jasmine": "~2.6.0"
   },
   "scripts": {
+    "eslint": "eslint *.js src spec",
     "test": "npm run jasmine",
-    "posttest": "npm run jshint",
-    "jshint": "jshint src ./ios-sim.js",
-    "postjshint": "npm run jscs",
-    "jscs": "jscs src ./ios-sim.js",
+    "posttest": "npm run eslint",
     "jasmine": "jasmine --config=spec/jasmine.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "author": "Shazron Abdullah",
   "license": "MIT",
   "dependencies": {
-    "plist": "^1.2.0",
-    "simctl": "^1.1.1",
+    "bplist-parser": "^0.0.6",
     "nopt": "1.0.9",
-    "bplist-parser": "^0.0.6"
+    "plist": "^2.1.0",
+    "simctl": "^1.1.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,0 +1,19 @@
+env:
+    jasmine: true
+
+rules:
+  # TBD easy fix:
+  padded-blocks: off
+  spaced-comment: off
+
+  # TODO resolve:
+  eol-last: off
+  semi: off
+
+  # TBD easy resolve:
+  key-spacing: off
+
+  # FUTURE TBD:
+  indent: off
+  quotes: off
+  space-before-function-paren: off

--- a/spec/commands.spec.js
+++ b/spec/commands.spec.js
@@ -17,22 +17,29 @@
     under the License.
 */
 var commands = require('../src/commands');
+var os = require('os');
 
 describe('commands end-to-end', function() {
 
     beforeEach(function() {
-      commands.init();
+      if (os.platform() === 'darwin') {
+        commands.init();
+      }
     });
 
     afterEach(function() {
     });
 
     it('command - showsdks', function() {
-      commands.showsdks({ 'no-output': true });
+      if (os.platform() === 'darwin') {
+        commands.showsdks({ 'no-output': true });
+      }
     });
 
     it('command - showdevicetypes', function() {
-      commands.showdevicetypes({ 'no-output': true });;
+      if (os.platform() === 'darwin') {
+        commands.showdevicetypes({ 'no-output': true });
+      }
     });
 
     it('command - launch', function() {
@@ -47,6 +54,8 @@ describe('commands end-to-end', function() {
 
     it('command - start', function() {
       var devicetypeid = 'iPhone-6';
-      commands.start({ 'devicetypeid': devicetypeid });
+      if (os.platform() === 'darwin') {
+        commands.start({ 'devicetypeid': devicetypeid });
+      }
     });
 });

--- a/src/.eslintrc.yml
+++ b/src/.eslintrc.yml
@@ -1,0 +1,21 @@
+rules:
+  # common src exception:
+  camelcase: off
+
+  # TBD easy fix:
+  padded-blocks: off
+
+  # TODO resolve:
+  eqeqeq: off
+  no-unused-vars: off
+  node/no-deprecated-api: off
+
+  # TBD easy resolve:
+  comma-spacing: off
+  no-useless-escape: off
+
+  # FUTURE TBD:
+  no-multiple-empty-lines: off
+  one-var: off
+  spaced-comment: off
+  space-before-function-paren: off


### PR DESCRIPTION
Based on `6.x` branch (`6.1.2`):
- mark `6.1.3-dev`
- updates from master branch:
  - CI updates
  - update repository url
  - migrate to esline
- use `plist@2` which supports node 4, with no `npm audit` issues at this time