### PR TITLE
Support iPhone XS, iPhone XS Max and iPhone XR

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -111,7 +111,7 @@ function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly, 
 }
 
 function findAvailableRuntime(list, device_name) {
-    device_name = device_name.toLowerCase()
+    device_name = device_name.toLowerCase();
 
     var all_druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true, { lowerCase: true });
     var druntime = all_druntimes[ filterDeviceName(device_name) ] || all_druntimes[ device_name ];
@@ -269,7 +269,7 @@ function filterDeviceName(deviceName) {
     }
     // replace ʀ in iPhone Xʀ
     if (deviceName.indexOf('ʀ') > -1) {
-      return deviceName.replace('ʀ', 'R')
+        return deviceName.replace('ʀ', 'R');
     }
     return deviceName;
 }

--- a/src/lib.js
+++ b/src/lib.js
@@ -71,7 +71,7 @@ function findFirstAvailableDevice(list) {
     return ret_obj;
 }
 
-function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly) {
+function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly, options = {}) {
     /*
         // Example result:
         {
@@ -91,6 +91,9 @@ function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly) 
         list.devices[deviceGroup].forEach(function(device) {
             var devicePropertyValue = device[deviceProperty];
 
+            if (options.lowerCase) {
+                devicePropertyValue = devicePropertyValue.toLowerCase();
+            }
             if (!runtimes[devicePropertyValue]) {
                 runtimes[devicePropertyValue] = [];
             }
@@ -108,8 +111,9 @@ function findRuntimesGroupByDeviceProperty(list, deviceProperty, availableOnly) 
 }
 
 function findAvailableRuntime(list, device_name) {
+    device_name = device_name.toLowerCase()
 
-    var all_druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true);
+    var all_druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true, { lowerCase: true });
     var druntime = all_druntimes[ filterDeviceName(device_name) ] || all_druntimes[ device_name ];
     var runtime_found = druntime && druntime.length > 0;
 
@@ -199,7 +203,7 @@ function getDeviceFromDeviceTypeId(devicetypeid) {
         // found the runtime, now find the actual device matching devicename
         if (deviceGroup === ret_obj.runtime) {
             return list.devices[deviceGroup].some(function(device) {
-                if (filterDeviceName(device.name) === filterDeviceName(ret_obj.name)) {
+                if (filterDeviceName(device.name).toLowerCase() === filterDeviceName(ret_obj.name).toLowerCase()) {
                     ret_obj.id = device.udid;
                     return true;
                 }
@@ -262,6 +266,10 @@ function filterDeviceName(deviceName) {
     // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
     if (deviceName.indexOf('iPad Pro') === 0) {
         return deviceName.replace(/\-/g, ' ').trim();
+    }
+    // replace ʀ in iPhone Xʀ
+    if (deviceName.indexOf('ʀ') > -1) {
+      return deviceName.replace('ʀ', 'R')
     }
     return deviceName;
 }
@@ -345,11 +353,11 @@ var lib = {
         var list = simctl.list(options).json;
         list = fixSimCtlList(list);
 
-        var druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true);
+        var druntimes = findRuntimesGroupByDeviceProperty(list, 'name', true, { lowerCase: true });
         var name_id_map = {};
 
         list.devicetypes.forEach(function(device) {
-            name_id_map[ filterDeviceName(device.name) ] = device.identifier;
+            name_id_map[ filterDeviceName(device.name).toLowerCase() ] = device.identifier;
         });
 
         list = [];
@@ -366,7 +374,7 @@ var lib = {
 
         for (var deviceName in druntimes) {
             var runtimes = druntimes[ deviceName ];
-            var dname = filterDeviceName(deviceName);
+            var dname = filterDeviceName(deviceName).toLowerCase();
 
             if (!(dname in name_id_map)) {
                 continue;

--- a/src/lib.js
+++ b/src/lib.js
@@ -264,7 +264,7 @@ function withInjectedEnvironmentVariablesToProcess(process, envVariables, action
 // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
 function filterDeviceName(deviceName) {
     // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
-    if (deviceName.indexOf('iPad Pro') === 0) {
+    if (/^iPad Pro/i.test(deviceName)) {
         return deviceName.replace(/\-/g, ' ').trim();
     }
     // replace ʀ in iPhone Xʀ


### PR DESCRIPTION
Addresses #235

Basically always `toLowerCase` device names when comparing, because depending on where the device name comes from there are many different formatting, i.e.:
- iPhone Xs Max
- iPhone XS Max
- iPhone XS MAX

Also normalized the ʀ character (`R != ʀ`). Comparing is always false otherwise even when `toLowerCase()`.

### Note for Cordova users:
Until this is merged / released and Cordova updates its dependencies, you may want to add ios-sim to your `devDependencies` and replace in your workflow:

```sh
cordova run --target=DEVICE_TYPE_ID
```

by

```sh
ios-sim launch platforms/ios/build/emulator/YOUR_APP.app --devicetypeid=DEVICE_TYPE_ID
```