### PR TITLE
Handle addition of iPhone XS (Max) and XR (#235)

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -262,6 +262,10 @@ function filterDeviceName(deviceName) {
     // replace hyphens in iPad Pro name which differ in 'Device Types' and 'Devices'
     if (deviceName.indexOf('iPad Pro') === 0) {
         return deviceName.replace(/\-/g, ' ').trim();
+    } else if (deviceName.indexOf('iPhone Xs') === 0) {
+      return deviceName.replace('Xs', 'XS');
+    } else if (deviceName.indexOf('iPhone Xʀ') === 0) {
+      return deviceName.replace('Xʀ', 'XR');
     }
     return deviceName;
 }


### PR DESCRIPTION
Like the iPad Pro, these have device names that do not match the device identifier. This does a replacement via filterDeviceName

Fixes #235 