### PR TITLE
Documentation updates & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![NPM](https://nodei.co/npm/ios-sim.png?compact=true)](https://nodei.co/npm/ios-sim/)
 [![Build status](https://ci.appveyor.com/api/projects/status/xh7auct40k5oxwjg/branch/master?svg=true
 )](https://ci.appveyor.com/project/shazron/ios-sim-bn5fo)
 [![Build Status](https://travis-ci.org/ios-control/ios-sim.svg?branch=master)](https://travis-ci.org/ios-control/ios-sim)
@@ -5,18 +6,16 @@
 ios-sim
 =======
 
-Supports Node 6 and greater, and Xcode 10 and greater -- since version 8.x.
+Supports Node 6 and greater, and Xcode 9.4 and greater -- since version 8.x.
 
-The ios-sim tool is a command-line utility that launches an iOS application on the iOS Simulator. This allows for niceties such as automated testing without having to open Xcode.
+The `ios-sim` tool is a command-line utility that launches an iOS application on the iOS Simulator. This allows for niceties such as automated testing without having to open Xcode.
 
 Features
 --------
 
-* Choose the device family to simulate, i.e. iPhone or iPad. Run using "showdevicetypes" option to see available device types, and pass it in as the "devicetypeid" parameter.
+* Choose the device family to simulate, i.e. iPhone or iPad. Run using `showdevicetypes` option to see available device types, and pass it in as the `devicetypeid` parameter.
 
 See the `--help` option for more info.
-
-The unimplemented options below are in the [backlog](https://github.com/phonegap/ios-sim/milestones/ios-sim%204.2.0)
 
 Usage
 -----
@@ -65,7 +64,7 @@ Choose one of the following installation methods.
 
 ### Node JS
 
-Install using node.js (at least 0.10.20):
+Install using Node.js (6 or greater):
 
     $ npm install ios-sim -g
 
@@ -85,17 +84,15 @@ Download using git clone:
 Troubleshooting
 ---------------
 
-Make sure you enable Developer Mode on your machine:
+Be sure to enable Developer Mode on your machine:
 
     $ DevToolsSecurity -enable
 
-Make sure multiple instances of launchd_sim are not running:
+Ensure that multiple instances of `launchd_sim` are not running:
 
     $ killall launchd_sim
 
 License
 -------
 
-This project is available under the MIT license. See [LICENSE][license].
-
-[license]: https://github.com/phonegap/ios-sim/blob/master/LICENSE
+This project is available under the MIT license. See [`LICENSE`][./LICENSE].


### PR DESCRIPTION
* Add compact npm badge
* Xcode 9.4 support
* use backticks
* remove obsolete backlog reference
* Update Node.js directions with minimum Node.js version 6
* Rewording in place of "make sure" in a couple places
* More direct link to `LICENSE`

One of the points is that I think we should still keep Xcode 9 support for a while.

An alternative would be to maintain Xcode 9 support in the 7.x branch instead of upcoming 8.0 release.