### PR TITLE
CI updates on 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,37 @@
 os: osx
-osx_image: xcode8.3
+
+osx_image:
+- xcode8.3
+- xcode9.4
+- xcode10.1
+
 sudo: false
+
 env:
   matrix:
+  - TRAVIS_NODE_VERSION: '0.10'
+  - TRAVIS_NODE_VERSION: '0.12'
   - TRAVIS_NODE_VERSION: '4'
   - TRAVIS_NODE_VERSION: '6'
+  - TRAVIS_NODE_VERSION: '8'
+  - TRAVIS_NODE_VERSION: '10'
+
 git:
   depth: 10
+
 before_install:
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
   && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
   install $TRAVIS_NODE_VERSION
 - node --version
 - npm --version
-- npm cache clean
-- npm install -g npm@3
+
 install:
 - npm install
+
 script:
-- npm test
+- npm run jasmine
+
 notifications:
   slack:
     secure: gn0YH0MCFOYR3Dd8Vsx3K/J9G0aazhnRjQVfqbeRKN3f6vToKif1CxhiDLXI6cxEB5DBiAtpK58jkoDYrXoNLGuSbiTHBJ+ankU8aG3s0OTIHa/8I0TjRKjBRc0PrMV7n7EiLC6LQxNe0x0mMSE1gdOUeS1UrZ5ZiVrS1u0eHHs=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,17 @@
 # http://www.appveyor.com/docs/appveyor-yml
 environment:
   matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "6"
+  - nodejs_version: "8"
+  - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm cache clean
-  - npm install -g npm@3
+  - node --version
+  - npm --version
   - npm install
 
 build: off
@@ -16,4 +20,4 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - npm run jasmine


### PR DESCRIPTION
* Add newer Node.js versions
* Add newer Xcode versions
* add blank lines to .travis.yml
* cover Node.js 0.10 & 0.12 on Travis CI & AppVeyor CI on 7.x only
  (for consistency with #node-js section of README.md on 7.x)
* appveyor.yml check node & npm version before npm install
* Skip npm cache clean & npm i -g npm@3 steps on 7.x
* run jasmine with no eslint on 7.x only
  (quick fix to avoid test failure on 0.10 & 0.12)

Most of these updates come from PR #239 & PR #240.