### PR TITLE
Log device information (8.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-sim",
-  "version": "8.0.1",
+  "version": "8.0.2-dev",
   "preferGlobal": "true",
   "description": "launch iOS apps into the iOS Simulator from the command line (Xcode 8.0+)",
   "main": "ios-sim.js",

--- a/src/lib.js
+++ b/src/lib.js
@@ -462,7 +462,7 @@ let lib = {
         console.log(util.format('device.name: %s', device.name))
         console.log(util.format('device.runtime: %s', device.runtime))
         console.log(util.format('device.id: %s', device.id))
-       
+
         // so now we have the deviceid, we can proceed
         simctl.extensions.start(device.id)
         simctl.install(device.id, app_path)

--- a/src/lib.js
+++ b/src/lib.js
@@ -458,6 +458,11 @@ let lib = {
         // --devicetypeid is a string in the form "devicetype, runtime_version" (optional: runtime_version)
         let device = getDeviceFromDeviceTypeId(devicetypeid)
 
+        // log device information
+        console.log(util.format('device.name: %s', device.name))
+        console.log(util.format('device.runtime: %s', device.runtime))
+        console.log(util.format('device.id: %s', device.id))
+       
         // so now we have the deviceid, we can proceed
         simctl.extensions.start(device.id)
         simctl.install(device.id, app_path)


### PR DESCRIPTION
Adds 3 log calls before handing over to `simctl` to do the actual launching.

Part of #254